### PR TITLE
Iterating on secret implementation:

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
         "-consul_addr", "192.168.50.2:8500",
         "-statsd_addr", "192.168.50.2:9125",
         "-basic_auth_secret_path", "provisioning/secrets",
-        "-enable_basic_auth=true"
+        "-enable_basic_auth=false"
       ],
       "showLog": true
     }

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -158,8 +158,8 @@ func TestHandlesRequestWithMemoryLimit(t *testing.T) {
 
 func TestHandlesRequestWithSecrets(t *testing.T) {
 	fr := createRequest()
-	fr.Secrets = []string{"secret/github/myvalue"}
-	expectedTemplate := `{{with secret "secret/github"}}{{.Data.myvalue}}{{end}}`
+	fr.Secrets = []string{"myvalue"}
+	expectedTemplate := `{{with secret "secret/openfaas/TestFunction"}}{{.Data.myvalue}}{{end}}`
 
 	h, rw, r := setupDeploy(fr.String())
 
@@ -169,6 +169,6 @@ func TestHandlesRequestWithSecrets(t *testing.T) {
 	job := args.Get(0).(*api.Job)
 	templates := job.TaskGroups[0].Tasks[0].Templates
 
-	assert.Equal(t, "/var/openfaas/secrets/myvalue", *templates[0].DestPath)
+	assert.Equal(t, "secrets/myvalue", *templates[0].DestPath)
 	assert.Equal(t, expectedTemplate, *templates[0].EmbeddedTmpl)
 }

--- a/provisioning/saltstack/pillar/base/init.sls
+++ b/provisioning/saltstack/pillar/base/init.sls
@@ -7,6 +7,6 @@ consul:
   version: 1.2.0
   user: root
 vault:
-  version: 0.10.4
+  version: 0.9.6
   service:
     type: systemd

--- a/provisioning/saltstack/salt/nomad/files/faas.hcl
+++ b/provisioning/saltstack/salt/nomad/files/faas.hcl
@@ -41,7 +41,7 @@ EOH
       }
 
       config {
-        image = "openfaas/gateway:0.8.12"
+        image = "openfaas/gateway:0.9.3"
 
         port_map {
           http = 8080


### PR DESCRIPTION
Hi @nicholasjackson, I wanted to iterate on the work you started for secrets, so here it is:

- updated vault key prefix to follow this convention: secret/openfaas/{function}
- updated deploy test to reflect changes
- Added mapped volumes to the secrets location to follow openfaas format
- secrets in a function.yml are now defined the same way as k8s, Swarm

Example Vault secret curl:
```bash
curl -i -H "X-Vault-Token: vagrant" -H "Content-Type: application/json" -X POST -d '{"cows_test":"TESTACCESS", "another_secret": "SECRET"}' https://{vault_host}:8200/v1/secret/openfaas/cows
```
Example faas-cli:
```bash
faas-cli store deploy cows --secret "cows_test" --secret "another_secret"  --gateway http://{gateway}:8080
```
The secrets are then present in the container:
```bash
sudo docker exec -it cows-{uuid} ls /var/openfaas/secrets
another_secret  cows_test
```

This makes it so that secrets are defined the say way in .yml or faas-cli regardless if openfaas is running on K8s, Swarm or Nomad. However, it is expected that the secrets be stored in this format in vault: secret/openfaas/{function}.