### PR TITLE
Change datacenter behaviour:

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,6 @@
       "request": "launch",
       "mode": "auto",
       "remotePath": "",
-      "port": 8080,
       "host": "0.0.0.0",
       "program": "${workspaceFolder}",
       "env": {},
@@ -21,7 +20,8 @@
         "-statsd_addr", "192.168.50.2:9125",
         "-basic_auth_secret_path", "provisioning/secrets",
         "-enable_basic_auth=false",
-        "-vault_default_policy", "openfaas"
+        "-vault_default_policy", "openfaas",
+        "-port=8081"
       ],
       "showLog": true
     }

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -26,7 +26,7 @@ func setupDeploy(body string) (http.HandlerFunc, *httptest.ResponseRecorder, *ht
 
 	logger := hclog.Default()
 
-	return MakeDeploy(mockJob, fntypes.ProviderConfig{VaultDefaultPolicy: "openfaas", VaultSecretPathPrefix: "secret/openfaas"}, logger, mockStats),
+	return MakeDeploy(mockJob, fntypes.ProviderConfig{VaultDefaultPolicy: "openfaas", VaultSecretPathPrefix: "secret/openfaas", Datacenter: "dc1"}, logger, mockStats),
 		httptest.NewRecorder(),
 		httptest.NewRequest("GET", "/system/functions", bytes.NewReader([]byte(body)))
 }
@@ -80,7 +80,7 @@ func TestHandlerRegistersWithFunctionProcess(t *testing.T) {
 
 func TestHandlesDataCentreLabelWithSingleDC(t *testing.T) {
 	fr := createRequest()
-	(*fr.Labels)["datacenters"] = "test"
+	fr.Constraints = []string{"datacenter == test"}
 
 	h, rw, r := setupDeploy(fr.String())
 
@@ -95,7 +95,7 @@ func TestHandlesDataCentreLabelWithSingleDC(t *testing.T) {
 
 func TestHandlesDataCentreLabelWithMultipleDC(t *testing.T) {
 	fr := createRequest()
-	(*fr.Labels)["datacenters"] = "test1,test2"
+	fr.Constraints = []string{"datacenter == test1", "datacenter == test2"}
 
 	h, rw, r := setupDeploy(fr.String())
 

--- a/main.go
+++ b/main.go
@@ -153,7 +153,7 @@ func createFaaSHandlers(nomadClient *api.Client, consulResolver *consul.Resolver
 	if err != nil {
 		datacenter = "dc1"
 	}
-	logger.Info("Datacenter from agent", datacenter)
+	logger.Info("Datacenter from agent:" + datacenter)
 
 	providerConfig := &fntypes.ProviderConfig{
 		VaultDefaultPolicy:    *vaultDefaultPolicy,

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var (
 	nodeURI               = flag.String("node_addr", "localhost", "URI of the current Nomad node, this address is used for reporting and logging")
 	nomadAddr             = flag.String("nomad_addr", "localhost:4646", "Address for Nomad API endpoint")
 	consulAddr            = flag.String("consul_addr", "http://localhost:8500", "Address for Consul API endpoint")
-  consulACL           = flag.String("consul_acl", "", "ACL token for Consul API, only required if ACL are enabled in Consul")
+	consulACL             = flag.String("consul_acl", "", "ACL token for Consul API, only required if ACL are enabled in Consul")
 	nomadRegion           = flag.String("nomad_region", "global", "Default region to schedule functions in")
 	enableBasicAuth       = flag.Bool("enable_basic_auth", false, "Flag for enabling basic authentication on gateway endpoints")
 	basicAuthSecretPath   = flag.String("basic_auth_secret_path", "/secrets", "The directory path to the basic auth secret file")
@@ -149,9 +149,16 @@ func main() {
 
 func createFaaSHandlers(nomadClient *api.Client, consulResolver *consul.Resolver, stats *statsd.Client, logger hclog.Logger) *types.FaaSHandlers {
 
+	datacenter, err := nomadClient.Agent().Datacenter()
+	if err != nil {
+		datacenter = "dc1"
+	}
+	logger.Info("Datacenter from agent", datacenter)
+
 	providerConfig := &fntypes.ProviderConfig{
 		VaultDefaultPolicy:    *vaultDefaultPolicy,
 		VaultSecretPathPrefix: *vaultSecretPathPrefix,
+		Datacenter:            datacenter,
 	}
 
 	return &types.FaaSHandlers{

--- a/nomad_job_files/faas.hcl
+++ b/nomad_job_files/faas.hcl
@@ -93,7 +93,7 @@ EOH
       }
 
       config {
-        image = "openfaas/gateway:0.8.12"
+        image = "openfaas/gateway:0.9.3"
 
         port_map {
           http = 8080

--- a/provisioning/saltstack/salt/nomad/files/faas.hcl
+++ b/provisioning/saltstack/salt/nomad/files/faas.hcl
@@ -28,7 +28,7 @@ job "faas-nomadd" {
         destination   = "secrets/gateway.env"
         // point the functions_provider_url to the host running vagrant (assuming a go process listening on 0.0.0.0), always .1 on last octet
         data = <<EOH
-functions_provider_url="http://{{ host_address }}:8080/"
+functions_provider_url="http://{{ host_address }}:8081/"
 {% raw -%}
 {{ range service "prometheus" }}
 faas_prometheus_host="{{ .Address }}"

--- a/types/provider_config.go
+++ b/types/provider_config.go
@@ -3,5 +3,5 @@ package types
 type ProviderConfig struct {
 	VaultDefaultPolicy    string
 	VaultSecretPathPrefix string
-	ConsulACLToken        string
+	Datacenter            string
 }


### PR DESCRIPTION
- on startup, use the agent's configured dc
- use constraints for datacenter overrides

This is the new datacenter format in the faas-cli:
```
faas-cli store deploy figlet --constraint "datacenter == test1"  --constraint "datacenter == test2" --gateway http://example:8080
```

This addresses the following issues:
#25 
#51 