### PR TITLE
Feature/consul dns

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -147,6 +147,8 @@ func createTask(r requests.CreateFunctionRequest, providerConfig types.ProviderC
 		Env: envVars,
 	}
 
+	task.Config["dns_servers"] = parseDNSServers(envVars)
+
 	if len(r.Secrets) > 0 {
 		task.Config["volumes"] = createSecretVolumes(r.Secrets)
 		task.Templates = createSecrets(providerConfig.VaultSecretPathPrefix, r.Service, r.Secrets)
@@ -279,4 +281,15 @@ func createSecrets(vaultPrefix string, name string, secrets []string) []*api.Tem
 	}
 
 	return templates
+}
+
+func parseDNSServers(envVars map[string]string) []string {
+
+	servers := []string{}
+	if val, ok := envVars["dns_servers"]; ok {
+		servers = strings.Split(val, ",")
+	} else {
+		servers = []string{"8.8.8.8", "8.8.4.4"}
+	}
+	return servers
 }

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -148,7 +148,7 @@ func createTask(r requests.CreateFunctionRequest, providerConfig types.ProviderC
 		Env: envVars,
 	}
 
-	task.Config["dns_servers"] = parseDNSServers(envVars, providerConfig.ConsulAddress)
+	task.Config["dns_servers"] = parseDNSServers(envVars, providerConfig)
 
 	if len(r.Secrets) > 0 {
 		task.Config["volumes"] = createSecretVolumes(r.Secrets)
@@ -284,16 +284,16 @@ func createSecrets(vaultPrefix string, name string, secrets []string) []*api.Tem
 	return templates
 }
 
-func parseDNSServers(envVars map[string]string, consulAddress string) []string {
+func parseDNSServers(envVars map[string]string, providerConfig types.ProviderConfig) []string {
 
 	servers := []string{}
-	u, urlErr := url.Parse(consulAddress)
+	u, urlErr := url.Parse(providerConfig.ConsulAddress)
 
 	// use dns servers from env vars first
 	if val, ok := envVars["dns_servers"]; ok {
 		servers = strings.Split(val, ",")
 		// try the configured consul host (assumes dns is available on port 53)
-	} else if urlErr == nil {
+	} else if providerConfig.ConsulDNSEnabled && urlErr == nil {
 		servers = []string{strings.Split(u.Host, ":")[0]}
 	} else {
 		servers = []string{"8.8.8.8", "8.8.4.4"}

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -147,7 +148,7 @@ func createTask(r requests.CreateFunctionRequest, providerConfig types.ProviderC
 		Env: envVars,
 	}
 
-	task.Config["dns_servers"] = parseDNSServers(envVars)
+	task.Config["dns_servers"] = parseDNSServers(envVars, providerConfig.ConsulAddress)
 
 	if len(r.Secrets) > 0 {
 		task.Config["volumes"] = createSecretVolumes(r.Secrets)
@@ -283,11 +284,17 @@ func createSecrets(vaultPrefix string, name string, secrets []string) []*api.Tem
 	return templates
 }
 
-func parseDNSServers(envVars map[string]string) []string {
+func parseDNSServers(envVars map[string]string, consulAddress string) []string {
 
 	servers := []string{}
+	u, urlErr := url.Parse(consulAddress)
+
+	// use dns servers from env vars first
 	if val, ok := envVars["dns_servers"]; ok {
 		servers = strings.Split(val, ",")
+		// try the configured consul host (assumes dns is available on port 53)
+	} else if urlErr == nil {
+		servers = []string{strings.Split(u.Host, ":")[0]}
 	} else {
 		servers = []string{"8.8.8.8", "8.8.4.4"}
 	}

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -26,7 +26,7 @@ func setupDeploy(body string) (http.HandlerFunc, *httptest.ResponseRecorder, *ht
 
 	logger := hclog.Default()
 
-	return MakeDeploy(mockJob, fntypes.ProviderConfig{VaultDefaultPolicy: "openfaas", VaultSecretPathPrefix: "secret/openfaas", Datacenter: "dc1", ConsulAddress: "http://localhost:8500"}, logger, mockStats),
+	return MakeDeploy(mockJob, fntypes.ProviderConfig{VaultDefaultPolicy: "openfaas", VaultSecretPathPrefix: "secret/openfaas", Datacenter: "dc1", ConsulAddress: "http://localhost:8500", ConsulDNSEnabled: true}, logger, mockStats),
 		httptest.NewRecorder(),
 		httptest.NewRequest("GET", "/system/functions", bytes.NewReader([]byte(body)))
 }

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -173,3 +173,20 @@ func TestHandlesRequestWithSecrets(t *testing.T) {
 	assert.Equal(t, "secrets/myvalue", *templates[0].DestPath)
 	assert.Equal(t, expectedTemplate, *templates[0].EmbeddedTmpl)
 }
+
+func TestHandlesRequestWithDNSServers(t *testing.T) {
+	fr := createRequest()
+	expectedServers := []string{"127.0.0.1", "127.0.1.1"}
+	fr.EnvVars = map[string]string{"dns_servers": "127.0.0.1,127.0.1.1"}
+
+	h, rw, r := setupDeploy(fr.String())
+
+	h(rw, r)
+
+	args := mockJob.Calls[0].Arguments
+	job := args.Get(0).(*api.Job)
+
+	dnsServers := job.TaskGroups[0].Tasks[0].Config["dns_servers"].([]string)
+
+	assert.Equal(t, expectedServers, dnsServers)
+}

--- a/main.go
+++ b/main.go
@@ -159,6 +159,7 @@ func createFaaSHandlers(nomadClient *api.Client, consulResolver *consul.Resolver
 		VaultDefaultPolicy:    *vaultDefaultPolicy,
 		VaultSecretPathPrefix: *vaultSecretPathPrefix,
 		Datacenter:            datacenter,
+		ConsulAddress:         *consulAddr,
 	}
 
 	return &types.FaaSHandlers{

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	nomadAddr             = flag.String("nomad_addr", "localhost:4646", "Address for Nomad API endpoint")
 	consulAddr            = flag.String("consul_addr", "http://localhost:8500", "Address for Consul API endpoint")
 	consulACL             = flag.String("consul_acl", "", "ACL token for Consul API, only required if ACL are enabled in Consul")
+	enableConsulDNS       = flag.Bool("enable_consul_dns", false, "Uses the consul_addr as a default DNS server. Assumes DNS interface is listening on port 53")
 	nomadRegion           = flag.String("nomad_region", "global", "Default region to schedule functions in")
 	enableBasicAuth       = flag.Bool("enable_basic_auth", false, "Flag for enabling basic authentication on gateway endpoints")
 	basicAuthSecretPath   = flag.String("basic_auth_secret_path", "/secrets", "The directory path to the basic auth secret file")
@@ -160,6 +161,7 @@ func createFaaSHandlers(nomadClient *api.Client, consulResolver *consul.Resolver
 		VaultSecretPathPrefix: *vaultSecretPathPrefix,
 		Datacenter:            datacenter,
 		ConsulAddress:         *consulAddr,
+		ConsulDNSEnabled:      *enableConsulDNS,
 	}
 
 	return &types.FaaSHandlers{

--- a/types/provider_config.go
+++ b/types/provider_config.go
@@ -5,4 +5,5 @@ type ProviderConfig struct {
 	VaultSecretPathPrefix string
 	Datacenter            string
 	ConsulAddress         string
+	ConsulDNSEnabled      bool
 }

--- a/types/provider_config.go
+++ b/types/provider_config.go
@@ -4,4 +4,5 @@ type ProviderConfig struct {
 	VaultDefaultPolicy    string
 	VaultSecretPathPrefix string
 	Datacenter            string
+	ConsulAddress         string
 }


### PR DESCRIPTION
I have a use case for using consul-style FQDNs in functions ( #58 ), so I thought it best to implement it like so:

1) Support setting dns_servers per function in env vars w/ gateway/faas-cli call:
```
environment:
      dns_servers: 127.0.0.1,127.0.1.1
```
2) Add optional faas-nomad cli param: `--enable_consul_dns` which uses the preexisting `--consul_addr` as the dns server

Also, this opens up the door for using the "direct functions" feature instead of our own proxy implementation.