### PR TITLE
Added of-watchdog http mode support (for #67):

### DIFF
--- a/handlers/mock_proxy_client.go
+++ b/handlers/mock_proxy_client.go
@@ -19,8 +19,8 @@ func (mp *MockProxyClient) GetFunctionName(r *http.Request) string {
 
 // CallAndReturnResponse returns a mock response
 func (mp *MockProxyClient) CallAndReturnResponse(address string, body []byte, h http.Header) (
-	[]byte, http.Header, error) {
+	[]byte, http.Header, int, error) {
 	args := mp.Called(address, body, h)
 
-	return args.Get(0).([]byte), args.Get(1).(http.Header), args.Error(2)
+	return args.Get(0).([]byte), args.Get(1).(http.Header), args.Get(2).(int), args.Error(3)
 }

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -72,7 +72,7 @@ func (p *Proxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respBody, respHeaders, err := p.callDownstreamFunction(service, urls, r)
+	respBody, respHeaders, respStatus, err := p.callDownstreamFunction(service, urls, r)
 
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -82,23 +82,25 @@ func (p *Proxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	setHeaders(respHeaders, rw)
+	rw.WriteHeader(respStatus)
 	rw.Write(respBody)
 }
 
-func (p *Proxy) callDownstreamFunction(service string, urls []string, r *http.Request) ([]byte, http.Header, error) {
+func (p *Proxy) callDownstreamFunction(service string, urls []string, r *http.Request) ([]byte, http.Header, int, error) {
 	reqBody, _ := ioutil.ReadAll(r.Body)
 	reqHeaders := r.Header
 	defer r.Body.Close()
 
 	var respBody []byte
 	var respHeaders http.Header
+	var respStatus int
 	var err error
 
 	lb := p.getLoadbalancer(service, urls)
 	lb.Do(func(endpoint url.URL) error {
 		// add the querystring from the request
 		endpoint.RawQuery = r.URL.RawQuery
-		respBody, respHeaders, err = p.client.CallAndReturnResponse(endpoint.String(), reqBody, reqHeaders)
+		respBody, respHeaders, respStatus, err = p.client.CallAndReturnResponse(endpoint.String(), reqBody, reqHeaders)
 		if err != nil {
 			return err
 		}
@@ -106,7 +108,7 @@ func (p *Proxy) callDownstreamFunction(service string, urls []string, r *http.Re
 		return nil
 	})
 
-	return respBody, respHeaders, err
+	return respBody, respHeaders, respStatus, err
 }
 
 func setHeaders(headers http.Header, rw http.ResponseWriter) {

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -72,7 +72,7 @@ func (p *Proxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respBody, respHeaders, respStatus, err := p.callDownstreamFunction(service, urls, r)
+	body, headers, status, err := p.callDownstreamFunction(service, urls, r)
 
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -81,9 +81,9 @@ func (p *Proxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setHeaders(respHeaders, rw)
-	rw.WriteHeader(respStatus)
-	rw.Write(respBody)
+	setHeaders(headers, rw)
+	rw.WriteHeader(status)
+	rw.Write(body)
 }
 
 func (p *Proxy) callDownstreamFunction(service string, urls []string, r *http.Request) ([]byte, http.Header, int, error) {

--- a/handlers/proxy_client_test.go
+++ b/handlers/proxy_client_test.go
@@ -58,7 +58,7 @@ func TestClientReturnsHeadersFromRequest(t *testing.T) {
 	c, r, s := setupProxyClient(body)
 	defer s.Close()
 
-	_, h, _ := c.CallAndReturnResponse(s.URL, body, r.Header)
+	_, h, _, _ := c.CallAndReturnResponse(s.URL, body, r.Header)
 
 	assert.Equal(t, "somevalue", h.Get("TESTHeader"))
 }
@@ -68,7 +68,7 @@ func TestClientReturnsBodysFromRequest(t *testing.T) {
 	c, r, s := setupProxyClient(body)
 	defer s.Close()
 
-	b, _, _ := c.CallAndReturnResponse(s.URL, body, r.Header)
+	b, _, _, _ := c.CallAndReturnResponse(s.URL, body, r.Header)
 
 	assert.Equal(t, "my body", string(b))
 }

--- a/handlers/proxy_test.go
+++ b/handlers/proxy_test.go
@@ -56,7 +56,7 @@ func TestProxyHandlerWithFunctionNameCallsResolve(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte{}, http.Header{}, 200, nil)
+		Return([]byte{}, http.Header{}, http.StatusOK, nil)
 	mockServiceResolver.On("Resolve", "function").Return([]string{"http://testaddress"})
 
 	h(rr, r)
@@ -68,7 +68,7 @@ func TestProxyHandlerCallsCallAndReturnResponse(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte{}, http.Header{}, 200, nil)
+		Return([]byte{}, http.Header{}, http.StatusOK, nil)
 	mockServiceResolver.On("Resolve", "function").Return([]string{"http://testaddress"})
 
 	h(rr, r)
@@ -83,7 +83,7 @@ func TestProxyHandlerReturnsErrorWhenNoEndpoints(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte{}, http.Header{}, 200, nil)
+		Return([]byte{}, http.Header{}, http.StatusOK, nil)
 	mockServiceResolver.On("Resolve", "function").Return([]string{})
 
 	h(rr, r)
@@ -99,12 +99,12 @@ func TestProxyHandlerReturnsErrorWhenClientError(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte{}, http.Header{}, 500, fmt.Errorf("Oops, I did it again"))
+		Return([]byte{}, http.Header{}, http.StatusInternalServerError, fmt.Errorf("Oops, I did it again"))
 	mockServiceResolver.On("Resolve", "function").Return([]string{"http://testaddress"})
 
 	h(rr, r)
 
-	assert.Equal(t, http.StatusInternalServerError, 500, rr.Code)
+	assert.Equal(t, http.StatusInternalServerError, http.StatusInternalServerError, rr.Code)
 }
 
 func TestProxyHandlerSetsHeadersOnSuccess(t *testing.T) {
@@ -114,13 +114,13 @@ func TestProxyHandlerSetsHeadersOnSuccess(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte{}, http.Header{"TestHeader": []string{"Testiculous"}}, 200, nil)
+		Return([]byte{}, http.Header{"TestHeader": []string{"faas-nomad"}}, http.StatusOK, nil)
 	mockServiceResolver.On("Resolve", "function").Return([]string{"http://testaddress"})
 
 	h(rr, r)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, "Testiculous", rr.Header().Get("TestHeader"), 200, nil)
+	assert.Equal(t, "faas-nomad", rr.Header().Get("TestHeader"), http.StatusOK, nil)
 }
 
 func TestProxyHandlerSetsBodyOnSuccess(t *testing.T) {
@@ -130,7 +130,7 @@ func TestProxyHandlerSetsBodyOnSuccess(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte("Something Something"), http.Header{}, 200, nil)
+		Return([]byte("Something Something"), http.Header{}, http.StatusOK, nil)
 	mockServiceResolver.On("Resolve", "function").Return([]string{"http://testaddress"})
 
 	h(rr, r)

--- a/handlers/proxy_test.go
+++ b/handlers/proxy_test.go
@@ -56,7 +56,7 @@ func TestProxyHandlerWithFunctionNameCallsResolve(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte{}, http.Header{}, nil)
+		Return([]byte{}, http.Header{}, 200, nil)
 	mockServiceResolver.On("Resolve", "function").Return([]string{"http://testaddress"})
 
 	h(rr, r)
@@ -68,7 +68,7 @@ func TestProxyHandlerCallsCallAndReturnResponse(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte{}, http.Header{}, nil)
+		Return([]byte{}, http.Header{}, 200, nil)
 	mockServiceResolver.On("Resolve", "function").Return([]string{"http://testaddress"})
 
 	h(rr, r)
@@ -83,7 +83,7 @@ func TestProxyHandlerReturnsErrorWhenNoEndpoints(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte{}, http.Header{}, nil)
+		Return([]byte{}, http.Header{}, 200, nil)
 	mockServiceResolver.On("Resolve", "function").Return([]string{})
 
 	h(rr, r)
@@ -99,12 +99,12 @@ func TestProxyHandlerReturnsErrorWhenClientError(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte{}, http.Header{}, fmt.Errorf("Oops, I did it again"))
+		Return([]byte{}, http.Header{}, 500, fmt.Errorf("Oops, I did it again"))
 	mockServiceResolver.On("Resolve", "function").Return([]string{"http://testaddress"})
 
 	h(rr, r)
 
-	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, http.StatusInternalServerError, 500, rr.Code)
 }
 
 func TestProxyHandlerSetsHeadersOnSuccess(t *testing.T) {
@@ -114,13 +114,13 @@ func TestProxyHandlerSetsHeadersOnSuccess(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte{}, http.Header{"TestHeader": []string{"Testiculous"}}, nil)
+		Return([]byte{}, http.Header{"TestHeader": []string{"Testiculous"}}, 200, nil)
 	mockServiceResolver.On("Resolve", "function").Return([]string{"http://testaddress"})
 
 	h(rr, r)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, "Testiculous", rr.Header().Get("TestHeader"))
+	assert.Equal(t, "Testiculous", rr.Header().Get("TestHeader"), 200, nil)
 }
 
 func TestProxyHandlerSetsBodyOnSuccess(t *testing.T) {
@@ -130,7 +130,7 @@ func TestProxyHandlerSetsBodyOnSuccess(t *testing.T) {
 	h, rr, r := setupProxy("")
 	mockProxyClient.On("GetFunctionName", mock.Anything).Return("function")
 	mockProxyClient.On("CallAndReturnResponse", mock.Anything, mock.Anything, mock.Anything).
-		Return([]byte("Something Something"), http.Header{}, nil)
+		Return([]byte("Something Something"), http.Header{}, 200, nil)
 	mockServiceResolver.On("Resolve", "function").Return([]string{"http://testaddress"})
 
 	h(rr, r)

--- a/nomad_job_files/faas.hcl
+++ b/nomad_job_files/faas.hcl
@@ -93,7 +93,7 @@ EOH
       }
 
       config {
-        image = "openfaas/gateway:0.9.11"
+        image = "openfaas/gateway:0.9.14"
 
         port_map {
           http = 8080

--- a/nomad_job_files/faas.hcl
+++ b/nomad_job_files/faas.hcl
@@ -93,7 +93,7 @@ EOH
       }
 
       config {
-        image = "openfaas/gateway:0.9.8"
+        image = "openfaas/gateway:0.9.11"
 
         port_map {
           http = 8080

--- a/provisioning/saltstack/salt/nomad/files/faas.hcl
+++ b/provisioning/saltstack/salt/nomad/files/faas.hcl
@@ -41,7 +41,7 @@ EOH
       }
 
       config {
-        image = "openfaas/gateway:0.9.11"
+        image = "openfaas/gateway:0.9.14"
 
         port_map {
           http = 8080

--- a/provisioning/saltstack/salt/nomad/files/faas.hcl
+++ b/provisioning/saltstack/salt/nomad/files/faas.hcl
@@ -41,7 +41,7 @@ EOH
       }
 
       config {
-        image = "openfaas/gateway:0.9.8"
+        image = "openfaas/gateway:0.9.11"
 
         port_map {
           http = 8080


### PR DESCRIPTION
When testing functions with of-watchdog/http mode, the upstream response needs to be honored by provider.

- Update proxy client to return status code
- Bump the faas gateway versions
- Update tests and mock client

Addresses: #67