### PR TITLE
Add support for registry auth in function deploy

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -156,6 +157,15 @@ func createTask(r requests.CreateFunctionRequest, providerConfig types.ProviderC
 		// TODO: check function annotations for vault policies
 		task.Vault = &api.Vault{
 			Policies: []string{providerConfig.Vault.DefaultPolicy},
+		}
+	}
+
+	if len(r.RegistryAuth) > 0 {
+		decoded, _ := base64.StdEncoding.DecodeString(r.RegistryAuth)
+		auth := strings.Split(string(decoded), ":")
+		task.Config["auth"] = map[string]interface{}{
+			"username": auth[0],
+			"password": auth[1],
 		}
 	}
 	return &task

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -163,9 +163,10 @@ func createTask(r requests.CreateFunctionRequest, providerConfig types.ProviderC
 	if len(r.RegistryAuth) > 0 {
 		decoded, _ := base64.StdEncoding.DecodeString(r.RegistryAuth)
 		auth := strings.Split(string(decoded), ":")
-		task.Config["auth"] = map[string]interface{}{
-			"username": auth[0],
-			"password": auth[1],
+		task.Config["auth"] = []map[string]interface{}{
+			map[string]interface{}{
+				"username": auth[0],
+				"password": auth[1]},
 		}
 	}
 	return &task

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -219,8 +219,8 @@ func TestHandleDeployWithRegistryAuth(t *testing.T) {
 
 	args := mockJob.Calls[0].Arguments
 	job := args.Get(0).(*api.Job)
-	auth := job.TaskGroups[0].Tasks[0].Config["auth"].(map[string]interface{})
+	auth := job.TaskGroups[0].Tasks[0].Config["auth"].([]map[string]interface{})
 
-	assert.Equal(t, "username", auth["username"])
-	assert.Equal(t, "password", auth["password"])
+	assert.Equal(t, "username", auth[0]["username"])
+	assert.Equal(t, "password", auth[0]["password"])
 }

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -205,4 +206,21 @@ func TestHandlesRequestUsingConsulAddress(t *testing.T) {
 	dnsServers := job.TaskGroups[0].Tasks[0].Config["dns_servers"].([]string)
 
 	assert.Equal(t, expectedServers, dnsServers)
+}
+
+func TestHandleDeployWithRegistryAuth(t *testing.T) {
+	fr := createRequest()
+	encoded := base64.StdEncoding.EncodeToString([]byte("username:password"))
+	fr.RegistryAuth = encoded
+
+	h, rw, r := setupDeploy(fr.String())
+
+	h(rw, r)
+
+	args := mockJob.Calls[0].Arguments
+	job := args.Get(0).(*api.Job)
+	auth := job.TaskGroups[0].Tasks[0].Config["auth"].(map[string]interface{})
+
+	assert.Equal(t, "username", auth["username"])
+	assert.Equal(t, "password", auth["password"])
 }


### PR DESCRIPTION
Support much needed private registry auth sent via faas-cli.