### PR TITLE
Feature/vault tls skip

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var (
 	enableBasicAuth       = flag.Bool("enable_basic_auth", false, "Flag for enabling basic authentication on gateway endpoints")
 	basicAuthSecretPath   = flag.String("basic_auth_secret_path", "/secrets", "The directory path to the basic auth secret file")
 	vaultAddrOverride     = flag.String("vault_addr", "", "Vault address override. Default Vault address is returned from the Nomad agent")
+	vaultTLSSkipVerify    = flag.Bool("vault_tls_skip_verify", false, "Skips TLS verification for calls to Vault. Not recommend for production")
 	vaultDefaultPolicy    = flag.String("vault_default_policy", "openfaas", "The default policy used when secrets are deployed with a function")
 	vaultSecretPathPrefix = flag.String("vault_secret_path_prefix", "secret/openfaas", "The Vault k/v path prefix used when secrets are deployed with a function")
 	vaultAppRoleID        = flag.String("vault_app_role_id", "", "A valid Vault AppRole role_id")
@@ -109,6 +110,7 @@ func createFaaSHandlers(nomadClient *api.Client, consulResolver *consul.Resolver
 	vaultConfig.SecretPathPrefix = *vaultSecretPathPrefix
 	vaultConfig.AppRoleID = *vaultAppRoleID
 	vaultConfig.AppSecretID = *vaultAppRoleSecretID
+	vaultConfig.TLSSkipVerify = *vaultTLSSkipVerify
 
 	providerConfig := &fntypes.ProviderConfig{
 		Vault:            vaultConfig,

--- a/types/vault_config.go
+++ b/types/vault_config.go
@@ -3,6 +3,7 @@ package types
 type VaultConfig struct {
 	Addr             string `json:"Addr"`
 	Enabled          bool   `json:"Enabled"`
+	TLSSkipVerify    bool
 	DefaultPolicy    string
 	SecretPathPrefix string
 	AppRoleID        string

--- a/vault/vault_service.go
+++ b/vault/vault_service.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -81,9 +82,15 @@ func (vs *VaultService) Login() (api.Secret, error) {
 func (vs *VaultService) DoRequest(method string, path string, body interface{}) (*http.Response, error) {
 
 	client := &http.Client{}
+	trIgnore := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
 	createRequest := vs.Client.NewRequest(method, path)
 	createRequest.SetJSONBody(body)
 
 	request, _ := createRequest.ToHTTP()
+	if vs.Config.TLSSkipVerify {
+		client.Transport = trIgnore
+	}
 	return client.Do(request)
 }

--- a/vault/vault_service.go
+++ b/vault/vault_service.go
@@ -7,10 +7,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/hashicorp/go-hclog"
-
-	"github.com/hashicorp/consul-template/dependency"
 	"github.com/hashicorp/faas-nomad/types"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/api"
 )
 
@@ -22,15 +20,11 @@ type VaultService struct {
 
 func NewVaultService(config *types.VaultConfig, log hclog.Logger) *VaultService {
 
-	vaultClient, _ := api.NewClient(api.DefaultConfig())
+	clientConfig := api.DefaultConfig()
+	clientConfig.ConfigureTLS(&api.TLSConfig{Insecure: config.TLSSkipVerify})
+	vaultClient, _ := api.NewClient(clientConfig)
 
 	vaultClient.SetAddress(config.Addr)
-
-	clientSet := dependency.NewClientSet()
-	clientSet.CreateVaultClient(&dependency.CreateVaultClientInput{
-		Address: config.Addr,
-		Token:   vaultClient.Token(),
-	})
 
 	vs := &VaultService{
 		Client: vaultClient,


### PR DESCRIPTION
In an environment where self-assigned certs and varying FQDN references are present, support TLS skip verification in the vault integration.