### PR TITLE
Feature/tls nomad endpoint

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,7 +82,6 @@ Vagrant.configure("2") do |config|
       salt.verbose = true
       salt.salt_call_args = ["saltenv=dev", "pillarenv=dev"]
     end
-    override.vm.provision "shell", path: "provisioning/scripts/vault_populate.sh"
     override.vm.provision "shell", path: "provisioning/scripts/nomad_run.sh"
   end
 
@@ -97,7 +96,6 @@ Vagrant.configure("2") do |config|
       salt.verbose = true
       salt.salt_call_args = ["saltenv=dev", "pillarenv=dev"]
     end
-    override.vm.provision "shell", path: "provisioning/scripts/vault_populate.sh"
     override.vm.provision "shell", path: "provisioning/scripts/nomad_run.sh"
   end
 
@@ -105,6 +103,8 @@ Vagrant.configure("2") do |config|
     d.run 'dev-vault', image: 'vault:0.9.6', 
       args: '-p 8200:8200 -e "VAULT_DEV_ROOT_TOKEN_ID=vagrant" -v /vagrant:/vagrant'
   end
+
+  config.vm.provision "shell", path: "provisioning/scripts/vault_populate.sh"
   #
   # View the documentation for the provider you are using for more
   # information on available options.
@@ -120,7 +120,7 @@ Vagrant.configure("2") do |config|
     cd /vagrant/provisioning/saltstack/formulas
     git clone https://github.com/saltstack-formulas/nomad-formula.git
     git clone https://github.com/saltstack-formulas/consul-formula.git
-    git clone https://github.com/saltstack-formulas/vault-formula.git
+    # git clone https://github.com/saltstack-formulas/vault-formula.git
   SHELL
   
   # salt

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ var (
 	nomadTLSCA            = flag.String("nomad_tls_ca", "", "The TLS ca certificate file location")
 	nomadTLSCert          = flag.String("nomad_tls_cert", "", "The TLS client certifcate file location")
 	nomadTLSKey           = flag.String("nomad_tls_key", "", "The TLS private key file location")
-	nomadTLSSkipVerify    = flag.Bool("noamd_tls_skip_verify", false, "Skips TLS verification for Nomad API. Not recommend for production")
+	nomadTLSSkipVerify    = flag.Bool("nomad_tls_skip_verify", false, "Skips TLS verification for Nomad API. Not recommend for production")
 	nomadACL              = flag.String("nomad_acl", "", "The ACL token for faas-nomad if Nomad ACLs are enabled")
 	consulAddr            = flag.String("consul_addr", "http://localhost:8500", "Address for Consul API endpoint")
 	consulACL             = flag.String("consul_acl", "", "ACL token for Consul API, only required if ACL are enabled in Consul")

--- a/provisioning/saltstack/pillar/dev/init.sls
+++ b/provisioning/saltstack/pillar/dev/init.sls
@@ -5,6 +5,11 @@ include:
 nomad:
   config:
     datacenter: dc1
+    tls:
+      http: True
+      ca_file: /home/vagrant/placeholder-ca.crt
+      cert_file: /home/vagrant/placeholder.crt
+      key_file: /home/vagrant/placeholder.key
     advertise:
       http: {{ interface_address }}
     server:
@@ -38,6 +43,14 @@ nomad:
     - dc1
 consul:
   config:
+    connect:
+      enabled: True
+      ca_provider: vault
+      ca_config:
+        address: "http://127.0.0.1:8200"
+        token: vagrant
+        root_pki_path: pki
+        intermediate_pki_path: pki_int
     server: True
     advertise_addr: {{ interface_address }}
     addresses:
@@ -50,15 +63,3 @@ consul:
     datacenter: dc1
     encrypt: "RIxqpNlOXqtr/j4BgvIMEw=="
     bootstrap: true
-vault:
-  listen_protocol: tcp
-  listen_port: 8200
-  listen_address: 0.0.0.0
-  tls_disable: 0
-  default_lease_ttl: 24h
-  max_lease_ttl: 24h
-  self_signed_cert:
-    enabled: false
-  backend: {}
-  dev_mode: true
-  dev_root_token: vagrant

--- a/provisioning/saltstack/salt/base/init.sls
+++ b/provisioning/saltstack/salt/base/init.sls
@@ -1,4 +1,3 @@
 include:
   - consul
-  - vault
   - nomad

--- a/provisioning/scripts/nomad_run.sh
+++ b/provisioning/scripts/nomad_run.sh
@@ -9,6 +9,11 @@ do
     sleep 2
   fi
 done
+
+export NOMAD_ADDR=https://192.168.50.2:4646
+export NOMAD_CACERT=/home/vagrant/placeholder-ca.crt
+export NOMAD_CLIENT_CERT=/home/vagrant/placeholder.crt
+export NOMAD_CLIENT_KEY=/home/vagrant/placeholder.key
 echo 'Waiting for nomad...'
 while true
 do

--- a/provisioning/scripts/vault_populate.sh
+++ b/provisioning/scripts/vault_populate.sh
@@ -19,7 +19,6 @@ export VAULT_ADDR=${VAULT_URL}
 export VAULT_TOKEN=${TOKEN}
 
 vault auth enable approle
-
 vault policy write ${POLICY_NAME} /vagrant/provisioning/scripts/policy.hcl
 
 # create approle openfaas
@@ -31,9 +30,35 @@ curl -i \
 
 curl -i \
   --header "X-Vault-Token: ${TOKEN}" \
-  ${VAULT_URL}/v1/auth/approle/role/${POLICY_NAME}/role-id
+  ${VAULT_URL}/v1/auth/approle/role/${POLICY_NAME}/role-id -o ./role_id.json
 
 curl -i \
   --header "X-Vault-Token: ${TOKEN}" \
   --request POST \
-  ${VAULT_URL}/v1/auth/approle/role/${POLICY_NAME}/secret-id
+  ${VAULT_URL}/v1/auth/approle/role/${POLICY_NAME}/secret-id -o ./secret_id.json
+
+echo 'enabling pki backend...'
+curl -i -H "X-Vault-Token: ${TOKEN}" -H "Content-Type: application/json" \
+  -XPOST -d '{"type":"pki"}' ${VAULT_URL}/v1/sys/mounts/pki
+
+echo 'generate root ca...'
+curl -i -H "X-Vault-Token: ${TOKEN}" -H "Content-Type: application/json" \
+  -XPOST -d '{"common_name":"nomad.local", "ip_sans": "192.168.50.2"}' ${VAULT_URL}/v1/pki/root/generate/internal
+
+echo 'configure issuing urls...'
+curl -i -H "X-Vault-Token: ${TOKEN}" -H "Content-Type: application/json" \
+  -XPOST -d '{"issuing_certificates": ["http://localhost:8200/v1/pki/ca"], "crl_distribution_points": ["http://localhost:8200/v1/pki/crl"]}' ${VAULT_URL}/v1/pki/config/urls
+
+echo 'create role...'
+curl -i -H "X-Vault-Token: ${TOKEN}" -H "Content-Type: application/json" \
+  -XPOST -d '{"allowed_domains": ["nomad.local"], "allow_subdomains": true, "max_ttl": "72h"}' ${VAULT_URL}/v1/pki/roles/faas-nomad
+
+echo 'get certficates...'
+curl -H "X-Vault-Token: ${TOKEN}" -H "Content-Type: application/json" \
+  -XPOST -d '{"common_name": "server.nomad.local", "ip_sans": "192.168.50.2"}' ${VAULT_URL}/v1/pki/issue/faas-nomad -o ./output.json
+
+apt-get install jq -y
+
+jq -r '.data.issuing_ca' < ./output.json > ./placeholder-ca.crt
+jq -r '.data.certificate' < ./output.json > ./placeholder.crt
+jq -r '.data.private_key' < ./output.json > ./placeholder.key

--- a/types/nomad_config.go
+++ b/types/nomad_config.go
@@ -1,0 +1,10 @@
+package types
+
+type NomadConfig struct {
+	Address       string
+	ACLToken      string
+	TLSCA         string
+	TLSCert       string
+	TLSPrivateKey string
+	TLSSkipVerify bool
+}

--- a/types/nomad_config.go
+++ b/types/nomad_config.go
@@ -1,6 +1,7 @@
 package types
 
 type NomadConfig struct {
+	TLSEnabled    bool
 	Address       string
 	ACLToken      string
 	TLSCA         string


### PR DESCRIPTION
Long overdue: Allows faas-nomad to connect to a Nomad TLS endpoint using tls arguments:
```
-enable_nomad_tls=true
-nomad_tls_skip_verify=false
-nomad_tls_ca /path/to/ca.crt
-nomad_tls_cert /path/to/client.crt
-nomad_tls_key /path/to/private.key
```
Addresses #19 
