### PR TITLE
Allow to change CPU arch constraint via commandline argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ $ echo "Nic" | faas-cli --gateway http://192.168.1.113:8080/ invoke gofunction
 That is all there is to it, checkout the OpenFaaS community page for some inspiration and other demos.
 [faas/community.md at master · openfaas/faas · GitHub](https://github.com/openfaas/faas/blob/master/community.md)
 
-### Datacenters and Constraints
-By default, the Nomad provider will use the datacenter of the Nomad agent or `dc1`. This can be overridden by setting one or more constraints `datacenter == value`.  Constraints for limiting CPU and memory can also be set `memory` is an integer representing Megabytes, `cpu` is an integer representing MHz of CPU where 1024 equals one core.
+### Datacenters and Limits
+By default, the Nomad provider will use the datacenter of the Nomad agent or `dc1`. This can be overridden by setting one or more constraints `datacenter == value`.  Limits for CPU and memory can also be set `memory` is an integer representing Megabytes, `cpu` is an integer representing MHz of CPU where 1024 equals one core.
 
 i.e.
 ```bash
@@ -286,6 +286,19 @@ functions:
     constraints:
       "datacenter == test1"
 ```
+
+### Nomad Job Constraints
+Additionally to the `datacenter` constraint [Nomad job constraints](https://www.nomadproject.io/docs/job-specification/constraint.html) are supported.
+
+i.e.
+```bash
+$ faas-cli deploy --constraint '${attr.cpu.arch} = arm'
+```
+
+For compatibility and convenience the interpolation notation (`${}`) can be left out and `==` instead of `=` is supported.
+
+All provided constraints are applied to the job (not the group or the task).
+Leaving out the a field (.e.g. `${meta.foo} is_set`) or using more than one operator (e.g. `${meta.foo} is_set = bar`) is currently __not supported__.
 
 ### Annotations
 Metadata can be added to the Nomad job definition through the use of the OpenFaaS annotation config.  The below example would add the key `git` to the `Meta` section of nomad job definition which can be accessed through the API.

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ var (
 	vaultSecretPathPrefix = flag.String("vault_secret_path_prefix", "secret/openfaas", "The Vault k/v path prefix used when secrets are deployed with a function")
 	vaultAppRoleID        = flag.String("vault_app_role_id", "", "A valid Vault AppRole role_id")
 	vaultAppRoleSecretID  = flag.String("vault_app_secret_id", "", "A valid Vault AppRole secret_id derived from the role")
+	cpuArchConstraint     = flag.String("cpu_arch_constraint", "amd64", "CPU architecture to constraint deployed functions to")
 )
 
 var functionTimeout = flag.Duration("function_timeout", 30*time.Second, "Timeout for function execution")
@@ -127,10 +128,11 @@ func createFaaSHandlers(nomadClient *api.Client, consulResolver *consul.Resolver
 	vaultConfig.TLSSkipVerify = *vaultTLSSkipVerify
 
 	providerConfig := &fntypes.ProviderConfig{
-		Vault:            vaultConfig,
-		Datacenter:       datacenter,
-		ConsulAddress:    *consulAddr,
-		ConsulDNSEnabled: *enableConsulDNS,
+		Vault:             vaultConfig,
+		Datacenter:        datacenter,
+		ConsulAddress:     *consulAddr,
+		ConsulDNSEnabled:  *enableConsulDNS,
+		CPUArchConstraint: *cpuArchConstraint,
 	}
 
 	vs := vault.NewVaultService(&vaultConfig, logger)

--- a/types/provider_config.go
+++ b/types/provider_config.go
@@ -1,8 +1,9 @@
 package types
 
 type ProviderConfig struct {
-	Vault            VaultConfig
-	Datacenter       string
-	ConsulAddress    string
-	ConsulDNSEnabled bool
+	Vault             VaultConfig
+	Datacenter        string
+	ConsulAddress     string
+	ConsulDNSEnabled  bool
+	CPUArchConstraint string
 }


### PR DESCRIPTION
I was able to start up faas-nomad on my RPi after some fiddling with the configuration, but I unfortunately was not able to run a function without patching the hard-coded CPU architecture constraint.

This might suffice as an alternative to use OpenFaas with Nomad purely on one architecture (e.g. a RPi cluster) until https://github.com/hashicorp/faas-nomad/issues/18 is implemented.