### PR TITLE
allowing consul service tags to be set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,3 +120,5 @@ require (
 	labix.org/v2/mgo v0.0.0-20140701140051-000000000287 // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )
+
+go 1.13

--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -139,6 +139,7 @@ func createTask(r requests.CreateFunctionRequest, providerConfig types.ProviderC
 			&api.Service{
 				Name:      r.Service,
 				PortLabel: "http",
+				Tags:      parseTags(envVars),
 			},
 		},
 		LogConfig: &api.LogConfig{
@@ -364,4 +365,13 @@ func parseDNSServers(envVars map[string]string, providerConfig types.ProviderCon
 		servers = []string{"8.8.8.8", "8.8.4.4"}
 	}
 	return servers
+}
+
+func parseTags(envVars map[string]string) []string {
+
+	tags := []string{}
+	if val, ok := envVars["tags"]; ok {
+		tags = strings.Split(val, ",")
+	}
+	return tags
 }

--- a/handlers/deploy_test.go
+++ b/handlers/deploy_test.go
@@ -192,6 +192,39 @@ func TestHandlesRequestWithDNSServers(t *testing.T) {
 	assert.Equal(t, expectedServers, dnsServers)
 }
 
+func TestHandlesRequestWithoutTags(t *testing.T) {
+	fr := createRequest()
+	expectedTags := []string{}
+
+	h, rw, r := setupDeploy(fr.String())
+
+	h(rw, r)
+
+	args := mockJob.Calls[0].Arguments
+	job := args.Get(0).(*api.Job)
+
+	Tags := job.TaskGroups[0].Tasks[0].Services[0].Tags
+
+	assert.Equal(t, expectedTags, Tags)
+}
+
+func TestHandlesRequestWithTags(t *testing.T) {
+	fr := createRequest()
+	expectedTags := []string{"foo", "bar"}
+	fr.EnvVars = map[string]string{"tags": "foo,bar"}
+
+	h, rw, r := setupDeploy(fr.String())
+
+	h(rw, r)
+
+	args := mockJob.Calls[0].Arguments
+	job := args.Get(0).(*api.Job)
+
+	Tags := job.TaskGroups[0].Tasks[0].Services[0].Tags
+
+	assert.Equal(t, expectedTags, Tags)
+}
+
 func TestHandlesRequestUsingConsulAddress(t *testing.T) {
 	fr := createRequest()
 	expectedServers := []string{"localhost"}


### PR DESCRIPTION
i have a need to setu consul service tag for the openfaas functions, i implemented this similar to https://github.com/hashicorp/faas-nomad/pull/65