### PR TITLE
Fixed error in faas.hcl, port_map object had comma that was not required.

### DIFF
--- a/nomad_job_files/faas.hcl
+++ b/nomad_job_files/faas.hcl
@@ -187,7 +187,7 @@ EOH
         ]
 
         port_map {
-          client = 4222,
+          client = 4222
           monitoring = 8222
           routing = 6222
         }

--- a/nomad_job_files/faas.hcl
+++ b/nomad_job_files/faas.hcl
@@ -187,7 +187,7 @@ EOH
         ]
 
         port_map {
-          client = 4222 
+          client = 4222
           monitoring = 8222
           routing = 6222
         }

--- a/nomad_job_files/faas.hcl
+++ b/nomad_job_files/faas.hcl
@@ -187,7 +187,7 @@ EOH
         ]
 
         port_map {
-          client = 4222
+          client = 4222 
           monitoring = 8222
           routing = 6222
         }


### PR DESCRIPTION
Comma causing faas.hcl job to not deploy, removed comma in port_mapping object. Tested as working in nomad version 1.0.1